### PR TITLE
update oauth.js, use request/request

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -1,7 +1,6 @@
 var crypto= require('crypto'),
     sha1= require('./sha1'),
-    http= require('http'),
-    https= require('https'),
+    request= require('request'),
     URL= require('url'),
     querystring= require('querystring'),
     OAuthUtils= require('./_utils');
@@ -239,21 +238,13 @@ exports.OAuth.prototype._getNonce= function(nonceSize) {
    return result.join('');
 }
 
-exports.OAuth.prototype._createClient= function( port, hostname, method, path, headers, sslEnabled ) {
-  var options = {
-    host: hostname,
-    port: port,
-    path: path,
-    method: method,
-    headers: headers
-  };
-  var httpModel;
-  if( sslEnabled ) {
-    httpModel= https;
-  } else {
-    httpModel= http;
-  }
-  return httpModel.request(options);
+exports.OAuth.prototype._createClient= function( parsedUrl, method, headers, post_body, options) {
+  return request[method.toLowerCase()]({
+      uri: parsedUrl,
+      headers: headers,
+      body: post_body,
+      followRedirect: options.followRedirects
+    });
 }
 
 exports.OAuth.prototype._prepareParameters= function( oauth_token, oauth_token_secret, method, url, extra_params ) {
@@ -349,32 +340,12 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
                        .replace(/\*/g, "%2A");
   }
 
-  if( post_body ) {
-      if ( Buffer.isBuffer(post_body) ) {
-          headers["Content-length"]= post_body.length;
-      } else {
-          headers["Content-length"]= Buffer.byteLength(post_body);
-      }
-  } else {
-      headers["Content-length"]= 0;
-  }
-
   headers["Content-Type"]= post_content_type;
-
-  var path;
+  if( method == "DELETE" ) method = "del"
   if( !parsedUrl.pathname  || parsedUrl.pathname == "" ) parsedUrl.pathname ="/";
-  if( parsedUrl.query ) path= parsedUrl.pathname + "?"+ parsedUrl.query ;
-  else path= parsedUrl.pathname;
 
-  var request;
-  if( parsedUrl.protocol == "https:" ) {
-    request= this._createClient(parsedUrl.port, parsedUrl.hostname, method, path, headers, true);
-  }
-  else {
-    request= this._createClient(parsedUrl.port, parsedUrl.hostname, method, path, headers);
-  }
+  var request = this._createClient(parsedUrl, method, headers, post_body, this._clientOptions)
 
-  var clientOptions = this._clientOptions;
   if( callback ) {
     var data="";
     var self= this;
@@ -389,13 +360,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
         if ( response.statusCode >= 200 && response.statusCode <= 299 ) {
           callback(null, data, response);
         } else {
-          // Follow 301 or 302 redirects with Location HTTP header
-          if((response.statusCode == 301 || response.statusCode == 302) && clientOptions.followRedirects && response.headers && response.headers.location) {
-            self._performSecureRequest( oauth_token, oauth_token_secret, method, response.headers.location, extra_params, post_body, post_content_type,  callback);
-          }
-          else {
-            callback({ statusCode: response.statusCode, data: data }, data, response);
-          }
+          callback({ statusCode: response.statusCode, data: data }, data, response);
         }
       }
     }
@@ -421,16 +386,9 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
         callback( err )
       }
     });
-
-    if( (method == "POST" || method =="PUT") && post_body != null && post_body != "" ) {
-      request.write(post_body);
-    }
     request.end();
   }
   else {
-    if( (method == "POST" || method =="PUT") && post_body != null && post_body != "" ) {
-      request.write(post_body);
-    }
     return request;
   }
 


### PR DESCRIPTION
Use request/request in `oauth.js`
since `request/request` handle most of networking stuff like `followRedirect` most of test removed from `tests/oauth.js`
